### PR TITLE
fix(#35): Avoid browser pull-down refresh on handheld devices

### DIFF
--- a/style/default.css
+++ b/style/default.css
@@ -8,6 +8,8 @@ html, body {
     margin: 0;
     display: flex;
     flex-direction: column;
+    overflow: hidden;
+    overscroll-behavior: none;
 }
 .link {
     display: flex;


### PR DESCRIPTION
### Description

Restricting pull-down refresh on mobile browsers using CSS

Fixes: #35 